### PR TITLE
Refactor Go Sprintf statements using Comby

### DIFF
--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -66,8 +66,8 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 	igMeta[openstack.TagKopsNetwork] = netName
 	igMeta["KopsInstanceGroup"] = ig.Name
 	igMeta["KopsRole"] = string(ig.Spec.Role)
-	igMeta[openstack.INSTANCE_GROUP_GENERATION] = fmt.Sprintf("%d", ig.GetGeneration())
-	igMeta[openstack.CLUSTER_GENERATION] = fmt.Sprintf("%d", b.Cluster.GetGeneration())
+	igMeta[openstack.INSTANCE_GROUP_GENERATION] = strconv.Itoa(ig.GetGeneration())
+	igMeta[openstack.CLUSTER_GENERATION] = strconv.Itoa(b.Cluster.GetGeneration())
 
 	if e, ok := ig.ObjectMeta.Annotations[openstack.OS_ANNOTATION+openstack.BOOT_FROM_VOLUME]; ok {
 		igMeta[openstack.BOOT_FROM_VOLUME] = e

--- a/pkg/util/templater/templater.go
+++ b/pkg/util/templater/templater.go
@@ -102,7 +102,7 @@ func indentContent(indent int, content string) string {
 			spacer = 0
 		}
 		// @step: write the line to the buffer
-		line := fmt.Sprintf("%"+fmt.Sprintf("%d", spacer)+"s%s", "", x)
+		line := fmt.Sprintf("%"+strconv.Itoa(spacer)+"s%s", "", x)
 		b.WriteString(line)
 
 		// @check if we need a newline

--- a/util/pkg/reflectutils/walk.go
+++ b/util/pkg/reflectutils/walk.go
@@ -161,7 +161,7 @@ func reflectRecursive(path string, v reflect.Value, visitor visitorFunc) error {
 		for i := 0; i < len; i++ {
 			av := v.Index(i)
 
-			childPath := path + "[" + fmt.Sprintf("%d", i) + "]"
+			childPath := path + "[" + strconv.Itoa(i) + "]"
 			err := visitor(childPath, nil, av)
 			if err != nil && err != SkipReflection {
 				return err


### PR DESCRIPTION
This campaign refactors Go code by replacing `fmt.Sprintf("%d", number)` statements with the equivalent but clearer `strconv.Itoa(number)`.

It uses [Comby](https://comby.dev) to do the replacement and then runs `gofmt` over the repositories.

Here is the action definition:

```json
{
  "scopeQuery": "lang:go fmt.Sprintf(\"%d\", fork:yes -repo:sourcegraph-testing/go",
  "steps": [
    {
      "type": "docker", "image": "comby/comby",
      "args": [ "-in-place", "fmt.Sprintf(\"%d\", :[v])", "strconv.Itoa(:[v])", ".go", "-matcher", ".go", "-d", "/work", "-exclude-dir", ".,vendor" ]
    },
    { "type": "docker", "image": "golang:1.14-alpine", "args": ["sh", "-c", "cd /work && go fmt ./..."] }
  ]
}
```